### PR TITLE
refactor: Replace Greynir with lemma.solberg.is API for lemmatization

### DIFF
--- a/planitor/language/lemma_api.py
+++ b/planitor/language/lemma_api.py
@@ -1,0 +1,99 @@
+"""
+HTTP client for lemma.solberg.is - Icelandic lemmatization API.
+
+This replaces the heavy Greynir-based lemmatization with a lightweight HTTP API,
+significantly reducing memory usage in worker processes.
+"""
+
+import logging
+from typing import List
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+LEMMA_API_URL = "https://lemma.solberg.is"
+TIMEOUT = 30  # seconds
+
+
+def lemmatize_text(text: str) -> List[str]:
+    """
+    Lemmatize text and return unique lemmas.
+    
+    Uses the /api/text endpoint which handles tokenization and returns
+    unique lemmas suitable for search indexing.
+    """
+    if not text or not text.strip():
+        return []
+    
+    try:
+        response = requests.post(
+            f"{LEMMA_API_URL}/api/text",
+            json={"text": text},
+            timeout=TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("lemmas", [])
+    except requests.RequestException as e:
+        logger.error(f"Lemma API error: {e}")
+        return []
+    except Exception as e:
+        logger.error(f"Unexpected error calling lemma API: {e}")
+        return []
+
+
+def lemmatize_word(word: str) -> List[str]:
+    """
+    Lemmatize a single word and return its lemmas.
+    
+    Uses the /api/lemmatize endpoint for single word lookups.
+    """
+    if not word or not word.strip():
+        return []
+    
+    try:
+        response = requests.post(
+            f"{LEMMA_API_URL}/api/lemmatize",
+            json={"word": word},
+            timeout=TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("lemmas", [])
+    except requests.RequestException as e:
+        logger.error(f"Lemma API error for word '{word}': {e}")
+        return [word]  # Fallback to original word
+    except Exception as e:
+        logger.error(f"Unexpected error calling lemma API: {e}")
+        return [word]
+
+
+def lemmatize_batch(words: List[str]) -> List[dict]:
+    """
+    Lemmatize multiple words in a single request.
+    
+    Uses the /api/batch endpoint for efficient batch processing.
+    Returns list of {"word": str, "lemmas": List[str]} dicts.
+    """
+    if not words:
+        return []
+    
+    # API limit is 1000 words per batch
+    words = words[:1000]
+    
+    try:
+        response = requests.post(
+            f"{LEMMA_API_URL}/api/batch",
+            json={"words": words},
+            timeout=TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("results", [])
+    except requests.RequestException as e:
+        logger.error(f"Lemma API batch error: {e}")
+        return [{"word": w, "lemmas": [w]} for w in words]
+    except Exception as e:
+        logger.error(f"Unexpected error calling lemma API: {e}")
+        return [{"word": w, "lemmas": [w]} for w in words]


### PR DESCRIPTION
## Summary

This PR replaces the heavy Greynir-based lemmatization with a lightweight HTTP API at lemma.solberg.is, significantly reducing memory usage in worker processes.

## Changes

- Add `planitor/language/lemma_api.py` - HTTP client for the lemma API
- Refactor `planitor/language/search.py` to use the API for `get_lemmas()` and `lemmatize_query()`
- Keep `GreynirBin` for `get_wordforms()` (search highlighting still needs word form expansion)
- Update tests to match new API behavior

## Benefits

- **Memory savings**: Workers no longer need to load Greynir's language models (~500MB+ per worker)
- **Simpler deployment**: No need to install heavy NLP dependencies for indexing
- **Same functionality**: Lemmatization results are comparable, just sourced from BÍN via API

## API Endpoints Used

- `/api/text` - Lemmatize full text (for indexing)
- `/api/lemmatize` - Single word lookup (for search queries)

## Notes

- Greynir/tokenizer dependencies are still needed elsewhere (company extraction, search highlighting, etc.)
- The API has rate limits (100 req/min) and size limits (50k chars) which should be fine for background indexing
- API fallback returns empty/original on errors to prevent indexing failures